### PR TITLE
fix: the document is rendered as a table due to a bug in the scroll area

### DIFF
--- a/enjoy/src/renderer/components/ui/scroll-area.tsx
+++ b/enjoy/src/renderer/components/ui/scroll-area.tsx
@@ -14,7 +14,7 @@ const ScrollArea = React.forwardRef<
     className={cn("relative overflow-hidden", className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit] [&>div]:!block">
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />


### PR DESCRIPTION
The document is nested inside `<div style="min-width: 100%;display: table;"></div>` due to a [bug](https://github.com/radix-ui/primitives/issues/2722) in `@radix-ui/react-scroll-area`, causing a rendering error.